### PR TITLE
Use yaml.safe_load() instead of yaml.load().

### DIFF
--- a/ari_backup/workflow.py
+++ b/ari_backup/workflow.py
@@ -165,7 +165,7 @@ class BaseWorkflow(object):
             return settings
         try:
             with open(self._settings_path, 'r') as settings_file:
-                settings = yaml.load(settings_file)
+                settings = yaml.safe_load(settings_file)
         except IOError:
             # We can't log anything yet because self.logger isn't set up yet.
             print ('Unable to load {} file. Continuing with default '


### PR DESCRIPTION
yaml.load() is unsafe[0], and calling load() wtihout a Loader
parameter is deprecated. This leads to the following warning:

YAMLLoadWarning: calling yaml.load()
without Loader=... is deprecated, as the default Loader is
unsafe. Please read https://msg.pyyaml.org/load for full
details.

This commit adjusts the package to use yaml.safe_load() instead.

[0] https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>